### PR TITLE
Feat: User access and personal profile editing 

### DIFF
--- a/src/main/java/com/academy/edge/studentmanager/controllers/StudentController.java
+++ b/src/main/java/com/academy/edge/studentmanager/controllers/StudentController.java
@@ -8,6 +8,8 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
 
@@ -45,5 +47,17 @@ public class StudentController {
     public ResponseEntity<Void> deleteStudent(@PathVariable String email){
         studentService.deleteStudent(email);
         return new ResponseEntity<>(HttpStatus.NO_CONTENT);
+    }
+
+    @GetMapping("/me")
+    public ResponseEntity<?> getCurrentStudent() {
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        if (authentication != null && authentication.isAuthenticated()) {
+            String email = authentication.getName();
+            StudentResponseDTO studentResponseDTO = studentService.getStudentByEmail(email);
+            return new ResponseEntity<>(studentResponseDTO, HttpStatus.OK);
+        } else {
+            return new ResponseEntity<>("No student logged in", HttpStatus.UNAUTHORIZED);
+        }
     }
 }

--- a/src/main/java/com/academy/edge/studentmanager/controllers/StudentController.java
+++ b/src/main/java/com/academy/edge/studentmanager/controllers/StudentController.java
@@ -9,11 +9,8 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
-import org.springframework.security.core.Authentication;
-import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
-import org.springframework.web.server.ResponseStatusException;
 
 import java.util.List;
 
@@ -52,7 +49,7 @@ public class StudentController {
     }
 
     @PutMapping({"/{email}"})
-    @PreAuthorize("hasAnyRole('ADMIN','INSTRUCTOR')")
+    @PreAuthorize("hasAnyRole('ADMIN','INSTRUCTOR') or authentication.name == #email")
     public ResponseEntity<StudentResponseDTO> updateStudentByEmail(@PathVariable String email,
                                                      @RequestBody @Valid StudentUpdateDTO studentUpdateDTO) {
         StudentResponseDTO studentResponseDTO = studentService.updateStudent(email, studentUpdateDTO);
@@ -61,49 +58,11 @@ public class StudentController {
     }
 
     @PutMapping({"/{email}/photo"})
-    @PreAuthorize("hasAnyRole('ADMIN','INSTRUCTOR')")
+    @PreAuthorize("hasAnyRole('ADMIN','INSTRUCTOR') or authentication.name == #email")
     public ResponseEntity<StudentResponseDTO> updateStudentPhotoByEmail(@PathVariable String email,
                                                                         @RequestParam("file") MultipartFile file) {
         StudentResponseDTO studentResponseDTO = studentService.updateStudentPhoto(email, file);
 
         return new ResponseEntity<>(studentResponseDTO, HttpStatus.OK);
-    }
-
-
-    @GetMapping("/me")
-    public ResponseEntity<StudentResponseDTO> getCurrentStudent() {
-        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
-        if (authentication != null && authentication.isAuthenticated()) {
-            String email = authentication.getName();
-            StudentResponseDTO studentResponseDTO = studentService.getStudentByEmail(email);
-            return new ResponseEntity<>(studentResponseDTO, HttpStatus.OK);
-        } else {
-            throw new ResponseStatusException(HttpStatus.UNAUTHORIZED, "No student logged in");
-        }
-    }
-
-    @PutMapping("/me")
-    public ResponseEntity<StudentResponseDTO> updateCurrentStudent(@RequestBody @Valid StudentUpdateDTO studentUpdateDTO) {
-        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
-        if (authentication != null && authentication.isAuthenticated()) {
-            String email = authentication.getName();
-            StudentResponseDTO studentResponseDTO = studentService.updateStudent(email, studentUpdateDTO);
-            return new ResponseEntity<>(studentResponseDTO, HttpStatus.OK);
-        } else {
-            throw new ResponseStatusException(HttpStatus.UNAUTHORIZED, "No student logged in");
-        }
-    }
-
-    @PutMapping("/me/photo")
-    public ResponseEntity<StudentResponseDTO> updateCurrentStudentPhoto(
-            @RequestParam("file") MultipartFile file) {
-        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
-        if (authentication != null && authentication.isAuthenticated()) {
-            String email = authentication.getName();
-            StudentResponseDTO studentResponseDTO = studentService.updateStudentPhoto(email, file);
-            return new ResponseEntity<>(studentResponseDTO, HttpStatus.OK);
-        } else {
-            throw new ResponseStatusException(HttpStatus.UNAUTHORIZED, "No student logged in");
-        }
     }
 }

--- a/src/main/java/com/academy/edge/studentmanager/controllers/StudentController.java
+++ b/src/main/java/com/academy/edge/studentmanager/controllers/StudentController.java
@@ -12,6 +12,7 @@ import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
+import org.springframework.web.server.ResponseStatusException;
 
 import java.util.List;
 
@@ -50,14 +51,14 @@ public class StudentController {
     }
 
     @GetMapping("/me")
-    public ResponseEntity<?> getCurrentStudent() {
+    public ResponseEntity<StudentResponseDTO> getCurrentStudent() {
         Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
         if (authentication != null && authentication.isAuthenticated()) {
             String email = authentication.getName();
             StudentResponseDTO studentResponseDTO = studentService.getStudentByEmail(email);
             return new ResponseEntity<>(studentResponseDTO, HttpStatus.OK);
         } else {
-            return new ResponseEntity<>("No student logged in", HttpStatus.UNAUTHORIZED);
+            throw new ResponseStatusException(HttpStatus.UNAUTHORIZED, "No student logged in");
         }
     }
 }

--- a/src/main/java/com/academy/edge/studentmanager/controllers/StudentController.java
+++ b/src/main/java/com/academy/edge/studentmanager/controllers/StudentController.java
@@ -2,6 +2,7 @@ package com.academy.edge.studentmanager.controllers;
 
 import com.academy.edge.studentmanager.dtos.StudentCreateDTO;
 import com.academy.edge.studentmanager.dtos.StudentResponseDTO;
+import com.academy.edge.studentmanager.dtos.StudentUpdateDTO;
 import com.academy.edge.studentmanager.services.StudentService;
 import jakarta.validation.Valid;
 import org.springframework.http.HttpStatus;
@@ -50,12 +51,56 @@ public class StudentController {
         return new ResponseEntity<>(HttpStatus.NO_CONTENT);
     }
 
+    @PutMapping({"/{email}"})
+    @PreAuthorize("hasAnyRole('ADMIN','INSTRUCTOR')")
+    public ResponseEntity<StudentResponseDTO> updateStudentByEmail(@PathVariable String email,
+                                                     @RequestBody @Valid StudentUpdateDTO studentUpdateDTO) {
+        StudentResponseDTO studentResponseDTO = studentService.updateStudent(email, studentUpdateDTO);
+
+        return new ResponseEntity<>(studentResponseDTO, HttpStatus.OK);
+    }
+
+    @PutMapping({"/{email}/photo"})
+    @PreAuthorize("hasAnyRole('ADMIN','INSTRUCTOR')")
+    public ResponseEntity<StudentResponseDTO> updateStudentPhotoByEmail(@PathVariable String email,
+                                                                        @RequestParam("file") MultipartFile file) {
+        StudentResponseDTO studentResponseDTO = studentService.updateStudentPhoto(email, file);
+
+        return new ResponseEntity<>(studentResponseDTO, HttpStatus.OK);
+    }
+
+
     @GetMapping("/me")
     public ResponseEntity<StudentResponseDTO> getCurrentStudent() {
         Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
         if (authentication != null && authentication.isAuthenticated()) {
             String email = authentication.getName();
             StudentResponseDTO studentResponseDTO = studentService.getStudentByEmail(email);
+            return new ResponseEntity<>(studentResponseDTO, HttpStatus.OK);
+        } else {
+            throw new ResponseStatusException(HttpStatus.UNAUTHORIZED, "No student logged in");
+        }
+    }
+
+    @PutMapping("/me")
+    public ResponseEntity<StudentResponseDTO> updateCurrentStudent(@RequestBody @Valid StudentUpdateDTO studentUpdateDTO) {
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        if (authentication != null && authentication.isAuthenticated()) {
+            String email = authentication.getName();
+            StudentResponseDTO studentResponseDTO = studentService.updateStudent(email, studentUpdateDTO);
+            return new ResponseEntity<>(studentResponseDTO, HttpStatus.OK);
+        } else {
+            throw new ResponseStatusException(HttpStatus.UNAUTHORIZED, "No student logged in");
+        }
+    }
+
+    @PutMapping("/me/photo")
+    public ResponseEntity<StudentResponseDTO> updateCurrentStudentPhoto(
+            @RequestParam("file") MultipartFile file) {
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        if (authentication != null && authentication.isAuthenticated()) {
+            String email = authentication.getName();
+            StudentResponseDTO studentResponseDTO = studentService.updateStudentPhoto(email, file);
             return new ResponseEntity<>(studentResponseDTO, HttpStatus.OK);
         } else {
             throw new ResponseStatusException(HttpStatus.UNAUTHORIZED, "No student logged in");

--- a/src/main/java/com/academy/edge/studentmanager/dtos/StudentResponseDTO.java
+++ b/src/main/java/com/academy/edge/studentmanager/dtos/StudentResponseDTO.java
@@ -14,6 +14,7 @@ public class StudentResponseDTO {
     private String id;
     private String name;
     private String photoUrl;
+    private String aboutMe;
     private Date birthDate;
     private Course course;
     private String registration;

--- a/src/main/java/com/academy/edge/studentmanager/dtos/StudentResponseDTO.java
+++ b/src/main/java/com/academy/edge/studentmanager/dtos/StudentResponseDTO.java
@@ -14,7 +14,7 @@ public class StudentResponseDTO {
     private String id;
     private String name;
     private String photoUrl;
-    private String aboutMe;
+    private String about;
     private Date birthDate;
     private Course course;
     private String registration;

--- a/src/main/java/com/academy/edge/studentmanager/dtos/StudentUpdateDTO.java
+++ b/src/main/java/com/academy/edge/studentmanager/dtos/StudentUpdateDTO.java
@@ -41,6 +41,6 @@ public class StudentUpdateDTO {
     @Pattern(regexp = "\\d{4}\\.[1-2]", message = "Informe um periodo válido")
     private String entryPeriod;
 
-    @Max(2600)
+    @Size(max = 2600)
     private String about;
 }

--- a/src/main/java/com/academy/edge/studentmanager/dtos/StudentUpdateDTO.java
+++ b/src/main/java/com/academy/edge/studentmanager/dtos/StudentUpdateDTO.java
@@ -41,5 +41,6 @@ public class StudentUpdateDTO {
     @Pattern(regexp = "\\d{4}\\.[1-2]", message = "Informe um periodo válido")
     private String entryPeriod;
 
-    private String aboutMe;
+    @Max(2600)
+    private String about;
 }

--- a/src/main/java/com/academy/edge/studentmanager/dtos/StudentUpdateDTO.java
+++ b/src/main/java/com/academy/edge/studentmanager/dtos/StudentUpdateDTO.java
@@ -1,0 +1,45 @@
+package com.academy.edge.studentmanager.dtos;
+
+import com.academy.edge.studentmanager.enums.Course;
+import com.academy.edge.studentmanager.validators.ValidBirthdate;
+import jakarta.validation.constraints.*;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+
+@Getter
+@AllArgsConstructor()
+public class StudentUpdateDTO {
+    @NotBlank(message = "Nome é obrigatório")
+    private String name;
+
+    @NotNull(message = "Insira uma data de nascimento")
+    @ValidBirthdate(message = "Informe uma data de nascimento válida")
+    private String birthDate;
+
+    @NotNull(message = "Curso é obrigatório")
+    private Course course;
+
+    @NotBlank(message = "Insira um número de matrícula")
+    @Pattern(regexp = "\\d+", message = "Informe uma matricula válida")
+    @Size(min = 8, max = 8, message = "Informe uma matrícula válida")
+    private String registration;
+
+    @NotBlank(message = "Insira um número de telefone")
+    @Pattern(regexp = "\\d{2}9\\d{8}", message = "Informe um número de telefone válido")
+    private String phone;
+
+    @Pattern(regexp = "(\\d{2}9\\d{8})|($)", message = "Informe um número de telefone secundário válido")
+    private String secondaryPhone;
+
+    @NotNull(message = "Insira o periodo")
+    @Max(10)
+    @Min(1)
+    private int period;
+
+    @NotBlank(message = "Insira o periodo de entrada no curso")
+    @Pattern(regexp = "\\d{4}\\.[1-2]", message = "Informe um periodo válido")
+    private String entryPeriod;
+
+    private String aboutMe;
+}

--- a/src/main/java/com/academy/edge/studentmanager/enums/Role.java
+++ b/src/main/java/com/academy/edge/studentmanager/enums/Role.java
@@ -3,5 +3,6 @@ package com.academy.edge.studentmanager.enums;
 public enum Role {
     USER,
     ADMIN,
-    INSTRUCTOR
+    INSTRUCTOR,
+    STUDENT
 }

--- a/src/main/java/com/academy/edge/studentmanager/models/Student.java
+++ b/src/main/java/com/academy/edge/studentmanager/models/Student.java
@@ -1,11 +1,16 @@
 package com.academy.edge.studentmanager.models;
 
 import com.academy.edge.studentmanager.enums.Course;
+import com.academy.edge.studentmanager.enums.Role;
 import jakarta.persistence.*;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
 
 import java.sql.Date;
+import java.util.Collection;
+import java.util.Collections;
 
 @EqualsAndHashCode(callSuper = true)
 @Entity
@@ -43,12 +48,12 @@ public class Student extends User{
     private Date entryDate;
 
     @Override
-    public String getDtype() {
-        return "Student";
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+        return Collections.singletonList(new SimpleGrantedAuthority("ROLE_"+ Role.STUDENT.name()));
     }
 
     @Override
-    public boolean isEnabled(){
-        return false;
+    public String getDtype() {
+        return "Student";
     }
 }

--- a/src/main/java/com/academy/edge/studentmanager/models/User.java
+++ b/src/main/java/com/academy/edge/studentmanager/models/User.java
@@ -46,6 +46,9 @@ public class User implements UserDetails {
     @Column
     String photoUrl;
 
+    @Column
+    String aboutMe;
+
     @CreationTimestamp
     @Column(updatable = false)
     Timestamp createdAt;

--- a/src/main/java/com/academy/edge/studentmanager/models/User.java
+++ b/src/main/java/com/academy/edge/studentmanager/models/User.java
@@ -47,7 +47,7 @@ public class User implements UserDetails {
     String photoUrl;
 
     @Column
-    String aboutMe;
+    String about;
 
     @CreationTimestamp
     @Column(updatable = false)

--- a/src/main/java/com/academy/edge/studentmanager/services/StudentService.java
+++ b/src/main/java/com/academy/edge/studentmanager/services/StudentService.java
@@ -2,6 +2,7 @@ package com.academy.edge.studentmanager.services;
 
 import com.academy.edge.studentmanager.dtos.StudentCreateDTO;
 import com.academy.edge.studentmanager.dtos.StudentResponseDTO;
+import com.academy.edge.studentmanager.dtos.StudentUpdateDTO;
 import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
 
@@ -15,8 +16,9 @@ public interface StudentService {
 
     StudentResponseDTO insertStudent(StudentCreateDTO studentCreateDTO, MultipartFile file);
 
-    //TODO: update student
-    //void updateStudent(String uuid, );
+    StudentResponseDTO updateStudent(String email, StudentUpdateDTO studentUpdateDTO);
+
+    StudentResponseDTO updateStudentPhoto(String email, MultipartFile file);
 
     void deleteStudent(String email);
 }

--- a/src/main/java/com/academy/edge/studentmanager/services/impl/StudentServiceImpl.java
+++ b/src/main/java/com/academy/edge/studentmanager/services/impl/StudentServiceImpl.java
@@ -127,7 +127,7 @@ public class StudentServiceImpl implements StudentService {
             s3Service.deleteFile(oldPhotoUrl);
         } catch (IOException e) {
             s3Service.deleteFile(newPhotoUrl);
-            throw new RuntimeException(e);
+            throw new ResponseStatusException(INTERNAL_SERVER_ERROR, "Error uploading the file");
         }
 
         student.setPhotoUrl(newPhotoUrl);

--- a/src/main/java/com/academy/edge/studentmanager/services/impl/StudentServiceImpl.java
+++ b/src/main/java/com/academy/edge/studentmanager/services/impl/StudentServiceImpl.java
@@ -4,7 +4,6 @@ import com.academy.edge.studentmanager.dtos.StudentCreateDTO;
 import com.academy.edge.studentmanager.dtos.StudentResponseDTO;
 import com.academy.edge.studentmanager.models.Invitation;
 import com.academy.edge.studentmanager.models.Student;
-import com.academy.edge.studentmanager.repositories.InvitationRepository;
 import com.academy.edge.studentmanager.repositories.StudentRepository;
 import com.academy.edge.studentmanager.services.InvitationService;
 import com.academy.edge.studentmanager.services.S3Service;

--- a/src/main/java/com/academy/edge/studentmanager/utils/DataInitializer.java
+++ b/src/main/java/com/academy/edge/studentmanager/utils/DataInitializer.java
@@ -3,12 +3,16 @@ package com.academy.edge.studentmanager.utils;
 
 import com.academy.edge.studentmanager.enums.InstructorSpecialization;
 import com.academy.edge.studentmanager.models.Instructor;
+import com.academy.edge.studentmanager.models.Invitation;
 import com.academy.edge.studentmanager.repositories.InstructorRepository;
+import com.academy.edge.studentmanager.repositories.InvitationRepository;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.CommandLineRunner;
 import org.springframework.context.annotation.Profile;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Component;
+
+import java.sql.Date;
 
 @Component
 @Profile("dev")
@@ -16,6 +20,9 @@ public class DataInitializer implements CommandLineRunner {
 
     @Autowired
     private InstructorRepository instructorRepository;
+
+    @Autowired
+    private InvitationRepository invitationRepository;
 
     @Autowired
     private PasswordEncoder passwordEncoder;
@@ -28,6 +35,18 @@ public class DataInitializer implements CommandLineRunner {
             instructor.setPassword(passwordEncoder.encode("Admin123"));
             instructor.setSpecialization(InstructorSpecialization.TECHNICAL);
             instructorRepository.save(instructor);
+        }
+
+        // Initialize 50 invitations for manual testing purposes :D
+        for (int i = 0; i < 50; i++) {
+            Invitation invitation = new Invitation();
+
+            invitation.setEmail(String.format("test%d@test.com", i));
+            invitation.setStudentGroup(1);
+            invitation.setEntryDate(Date.valueOf("2001-01-01"));
+            invitation.setCode(String.valueOf(i));
+
+            invitationRepository.save(invitation);
         }
     }
 }


### PR DESCRIPTION
Esta PR inclui as tasks: 53, 79, 81, e 85 do Jira.

EDGGA-53 - Liberar o login do aluno:

O commit "feat: enabling student login an adding Student new role" introduz as alterações no código necessárias para ativar o login do aluno e permitir sua autenticação e autorização no sistema. Nele foi criado uma nova role no back-end chamada Student, que vai referenciar as permissões dos estudantes do sistema. 

A rota para o login permanece a mesma.

![image](https://github.com/Edge-Academy-UFAL/student-manager/assets/108153768/72271e3a-10c6-4acf-bffb-2decd4c1357f)

Junto a isto, também foi criado a rota "/students/me" para permitir que o estudante logado fizesse o retrieve de suas próprias informações, considerando que por enquanto o estudante só conseguiria ter acesso às próprias informações.

![image](https://github.com/Edge-Academy-UFAL/student-manager/assets/108153768/b7e97715-1f32-4a8f-834f-bffd1c4baf25)

EDGGA-81 - Alterar o banco e a rota da API para conter o texto "sobre mim" na resposta 

No commit "feat: adding aboutMe field..." foi adicionado o campo no banco e no StudentResponseDTO. Agora o retrieve dos dados dos alunos retornam este campo:

![image](https://github.com/Edge-Academy-UFAL/student-manager/assets/108153768/74899616-d411-4809-826a-b1765a1ef2ea)

EDGGA-79 - Implementar edição de dados pessoais do aluno

Esta feature foi implementada no commit "feat: adding update endpoints for admins and students" onde foi adicionado os seguintes endpoints:

put "/students/me" para o próprio aluno editar suas informações com sua autenticação
![image](https://github.com/Edge-Academy-UFAL/student-manager/assets/108153768/de44a15b-a794-406d-bd00-62aa6182d60b)

put "students/{email}" para o admin e o instrutor poder editar as informações de um aluno específico pelo seu email
![image](https://github.com/Edge-Academy-UFAL/student-manager/assets/108153768/46471904-cb49-4e75-9515-3b312f17a771)


As informações que podem ser alteradas foram baseadas na história de usuário e seus critérios de aceite, sendo neste formato o body da requisição:

`{
    "name": "Ricardo",
    "birthDate": "2005-01-18",
    "course": "COMPUTER_SCIENCE",
    "aboutMe": "Im very cool",
    "registration": "20220101",
    "phone": "82993345595",
    "secondaryPhone": "82993345543",
    "period": "4",
    "entryPeriod": "2023.1"
}`

EDGGA-85 - Substituir a foto de perfil de usuário no localstack

Foi incluído esta funcionalidade no commit "feat: adding student photo update endpoints for admins and students", onde foi adicionado duas rotas:

put "/students/me/photo" para que o próprio aluno possa trocar sua foto de perfil
![image](https://github.com/Edge-Academy-UFAL/student-manager/assets/108153768/93c731a3-beee-46dc-ab77-bbdd30394803)

put "/students/{email}/photo" para o admin e o instrutor poder trocar a foto de perfil de um aluno específico pelo seu email
![image](https://github.com/Edge-Academy-UFAL/student-manager/assets/108153768/eb018cf7-bb40-45d8-b844-0e9dcbc46c4b)

A foto de perfil é enviada com sucesso para o localstack:
![image](https://github.com/Edge-Academy-UFAL/student-manager/assets/108153768/4271c39d-30a0-46b2-bda8-617207ecc047)

Também foi incluído nesta PR dois commits adicionais, "feat: adding a method..." que adiciona um método para criar invitations para testes no perfil de dev para facilitar os testes e também um fix do retorno de erro caso o usuário não esteja autenticado.