### PR TITLE
Feat: Endpoint para upload do histórico do aluno no storage e campo para guardar a URL do histórico

### DIFF
--- a/src/main/java/com/academy/edge/studentmanager/controllers/StudentController.java
+++ b/src/main/java/com/academy/edge/studentmanager/controllers/StudentController.java
@@ -68,11 +68,11 @@ public class StudentController {
 
     @PutMapping({"/{email}/record"})
     @PreAuthorize("hasAnyRole('ADMIN', 'INSTRUCTOR') or authentication.name == #email")
-    public ResponseEntity<Void> updateStudentAcademicRecordByEmail(
+    public ResponseEntity<StudentResponseDTO> updateStudentAcademicRecordByEmail(
             @PathVariable String email,
             @RequestParam("file") MultipartFile file) {
-        studentService.updateStudentAcademicRecord(email, file);
+        StudentResponseDTO studentResponseDTO = studentService.updateStudentAcademicRecord(email, file);
 
-        return new ResponseEntity<>(HttpStatus.OK);
+        return new ResponseEntity<>(studentResponseDTO, HttpStatus.OK);
     }
 }

--- a/src/main/java/com/academy/edge/studentmanager/controllers/StudentController.java
+++ b/src/main/java/com/academy/edge/studentmanager/controllers/StudentController.java
@@ -65,4 +65,14 @@ public class StudentController {
 
         return new ResponseEntity<>(studentResponseDTO, HttpStatus.OK);
     }
+
+    @PutMapping({"/{email}/record"})
+    @PreAuthorize("hasAnyRole('ADMIN', 'INSTRUCTOR') or authentication.name == #email")
+    public ResponseEntity<Void> updateStudentAcademicRecordByEmail(
+            @PathVariable String email,
+            @RequestParam("file") MultipartFile file) {
+        studentService.updateStudentAcademicRecord(email, file);
+
+        return new ResponseEntity<>(HttpStatus.OK);
+    }
 }

--- a/src/main/java/com/academy/edge/studentmanager/dtos/StudentResponseDTO.java
+++ b/src/main/java/com/academy/edge/studentmanager/dtos/StudentResponseDTO.java
@@ -14,6 +14,7 @@ public class StudentResponseDTO {
     private String id;
     private String name;
     private String photoUrl;
+    private String academicRecordUrl;
     private String about;
     private Date birthDate;
     private Course course;

--- a/src/main/java/com/academy/edge/studentmanager/models/Student.java
+++ b/src/main/java/com/academy/edge/studentmanager/models/Student.java
@@ -46,6 +46,9 @@ public class Student extends User{
     @Column(nullable = false)
     private int studentGroup;
 
+    @Column()
+    private String academicRecordUrl;
+
     @Column(nullable = false)
     private Date entryDate;
 

--- a/src/main/java/com/academy/edge/studentmanager/services/StudentService.java
+++ b/src/main/java/com/academy/edge/studentmanager/services/StudentService.java
@@ -22,5 +22,5 @@ public interface StudentService {
 
     void deleteStudent(String email);
 
-    void updateStudentAcademicRecord(String email, MultipartFile file);
+    StudentResponseDTO updateStudentAcademicRecord(String email, MultipartFile file);
 }

--- a/src/main/java/com/academy/edge/studentmanager/services/StudentService.java
+++ b/src/main/java/com/academy/edge/studentmanager/services/StudentService.java
@@ -21,4 +21,6 @@ public interface StudentService {
     StudentResponseDTO updateStudentPhoto(String email, MultipartFile file);
 
     void deleteStudent(String email);
+
+    void updateStudentAcademicRecord(String email, MultipartFile file);
 }

--- a/src/main/java/com/academy/edge/studentmanager/services/impl/StudentServiceImpl.java
+++ b/src/main/java/com/academy/edge/studentmanager/services/impl/StudentServiceImpl.java
@@ -168,10 +168,10 @@ public class StudentServiceImpl implements StudentService {
         String newAcademicRecordUrl =  "historico_" + student.getName() + "_" + currentDate + "_" + ".pdf";
 
         try {
-            if (!Objects.equals(oldAcademicRecordUrl, newAcademicRecordUrl)) {
+            if (!Objects.equals(oldAcademicRecordUrl, newAcademicRecordUrl) && !oldAcademicRecordUrl.isBlank()) {
                 s3Service.deleteFile(oldAcademicRecordUrl);
             }
-            // O sistema da S3 atualiza o arquivos
+            // O sistema da S3 atualiza o arquivos de mesmo nome, sobrescrevendo
             s3Service.uploadFile(newAcademicRecordUrl, file);
         } catch (IOException e) {
             s3Service.deleteFile(newAcademicRecordUrl);

--- a/src/main/java/com/academy/edge/studentmanager/services/impl/StudentServiceImpl.java
+++ b/src/main/java/com/academy/edge/studentmanager/services/impl/StudentServiceImpl.java
@@ -168,7 +168,9 @@ public class StudentServiceImpl implements StudentService {
         String newAcademicRecordUrl =  "historico_" + student.getName() + "_" + currentDate + "_" + ".pdf";
 
         try {
-            if (!Objects.equals(oldAcademicRecordUrl, newAcademicRecordUrl) && !oldAcademicRecordUrl.isBlank()) {
+            if (!Objects.equals(oldAcademicRecordUrl, newAcademicRecordUrl)
+                    && oldAcademicRecordUrl != null
+                    && !oldAcademicRecordUrl.isEmpty()) {
                 s3Service.deleteFile(oldAcademicRecordUrl);
             }
             // O sistema da S3 atualiza o arquivos de mesmo nome, sobrescrevendo

--- a/src/main/java/com/academy/edge/studentmanager/services/impl/StudentServiceImpl.java
+++ b/src/main/java/com/academy/edge/studentmanager/services/impl/StudentServiceImpl.java
@@ -164,9 +164,14 @@ public class StudentServiceImpl implements StudentService {
         LocalDate currentDate = LocalDate.now();
 
         // e.g. format: "historico_JohnDoe_2024-01-04.pdf
+        String oldAcademicRecordUrl = student.getAcademicRecordUrl();
         String newAcademicRecordUrl =  "historico_" + student.getName() + "_" + currentDate + "_" + ".pdf";
 
         try {
+            if (!Objects.equals(oldAcademicRecordUrl, newAcademicRecordUrl)) {
+                s3Service.deleteFile(oldAcademicRecordUrl);
+            }
+            // O sistema da S3 atualiza o arquivos
             s3Service.uploadFile(newAcademicRecordUrl, file);
         } catch (IOException e) {
             s3Service.deleteFile(newAcademicRecordUrl);

--- a/src/main/java/com/academy/edge/studentmanager/services/impl/StudentServiceImpl.java
+++ b/src/main/java/com/academy/edge/studentmanager/services/impl/StudentServiceImpl.java
@@ -146,7 +146,7 @@ public class StudentServiceImpl implements StudentService {
     }
 
     @Override
-    public void updateStudentAcademicRecord(String email, MultipartFile file) {
+    public StudentResponseDTO updateStudentAcademicRecord(String email, MultipartFile file) {
         Student student = studentRepository.findByEmail(email).orElseThrow(
                 () -> new ResponseStatusException(NOT_FOUND, "Student not found"));
 
@@ -165,5 +165,7 @@ public class StudentServiceImpl implements StudentService {
 
         student.setAcademicRecordUrl(newAcademicRecordUrl);
         studentRepository.save(student);
+
+        return modelMapper.map(student, StudentResponseDTO.class);
     }
 }

--- a/src/main/java/com/academy/edge/studentmanager/services/impl/StudentServiceImpl.java
+++ b/src/main/java/com/academy/edge/studentmanager/services/impl/StudentServiceImpl.java
@@ -18,6 +18,7 @@ import org.springframework.web.multipart.MultipartFile;
 import org.springframework.web.server.ResponseStatusException;
 
 import java.io.IOException;
+import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -160,7 +161,10 @@ public class StudentServiceImpl implements StudentService {
             throw new ResponseStatusException(BAD_REQUEST, "File size is biggest than 2MB");
         }
 
-        String newAcademicRecordUrl =  "historico_" + student.getName() + ".pdf";
+        LocalDate currentDate = LocalDate.now();
+
+        // e.g. format: "historico_JohnDoe_2024-01-04.pdf
+        String newAcademicRecordUrl =  "historico_" + student.getName() + "_" + currentDate + "_" + ".pdf";
 
         try {
             s3Service.uploadFile(newAcademicRecordUrl, file);

--- a/src/main/java/com/academy/edge/studentmanager/services/impl/StudentServiceImpl.java
+++ b/src/main/java/com/academy/edge/studentmanager/services/impl/StudentServiceImpl.java
@@ -147,11 +147,17 @@ public class StudentServiceImpl implements StudentService {
 
     @Override
     public StudentResponseDTO updateStudentAcademicRecord(String email, MultipartFile file) {
+        long MAX_RECORD_FILE_SIZE = 2000000L; // 2MB
+
         Student student = studentRepository.findByEmail(email).orElseThrow(
                 () -> new ResponseStatusException(NOT_FOUND, "Student not found"));
 
         if(!Objects.equals(file.getContentType(), documentContentType)){
             throw new ResponseStatusException(BAD_REQUEST, "File is not a PDF file");
+        }
+
+        if(file.getSize() > MAX_RECORD_FILE_SIZE) {
+            throw new ResponseStatusException(BAD_REQUEST, "File size is biggest than 2MB");
         }
 
         String newAcademicRecordUrl =  "historico_" + student.getName() + ".pdf";

--- a/src/main/java/com/academy/edge/studentmanager/utils/DataInitializer.java
+++ b/src/main/java/com/academy/edge/studentmanager/utils/DataInitializer.java
@@ -41,7 +41,7 @@ public class DataInitializer implements CommandLineRunner {
         for (int i = 0; i < 50; i++) {
             Invitation invitation = new Invitation();
 
-            invitation.setEmail(String.format("test%d@test.com", i));
+            invitation.setEmail(String.format("test%d@edge.ufal.br", i));
             invitation.setStudentGroup(1);
             invitation.setEntryDate(Date.valueOf("2001-01-01"));
             invitation.setCode(String.valueOf(i));

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -30,6 +30,10 @@ aws.secret.key = ${AWS_SECRET_KEY:wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY}
 aws.s3.bucket = ${AWS_S3_BUCKET:student-manager-files}
 aws.url = ${AWS_URL:http://127.0.0.1:4566}
 
+#Spring Multipart
+spring.servlet.multipart.max-file-size=10MB
+spring.servlet.multipart.max-request-size=10MB
+spring.servlet.multipart.resolve-lazily=true
 
 spring.profiles.active=${spring_profile_active:dev}
 


### PR DESCRIPTION
O campo de URL do histórico foi adicionado no modelo do usuário:

![image](https://github.com/Edge-Academy-UFAL/student-manager/assets/108153768/56efc3bf-efe2-471e-a960-0abe86bec87a)

Foi adicionado um novo endpoint `/api/v1/students/{email}/record` que servirá para atualizar o histórico do aluno.
Tanto o próprio aluno autenticado quanto instrutores e administradores do sistema poderão fazer essa operação.

![image](https://github.com/Edge-Academy-UFAL/student-manager/assets/108153768/b4cbfee6-0f30-4d72-8f5c-ffc9b32406dc)

Há três validações, duas delas sendo novas com relação às anteriores implementações de upload de arquivo.

> I. O sistema verifica se o arquivo é maior que 2MB antes de salvar, caso seja, retorna um erro
>
> ![image](https://github.com/Edge-Academy-UFAL/student-manager/assets/108153768/12db11f2-916c-47ef-8745-1450d87fd7e7)
>
> II. O sistema verifica se o arquivo é de extensão diferente de PDF antes de salvar, caso seja, retorna um erro
>
> ![image](https://github.com/Edge-Academy-UFAL/student-manager/assets/108153768/aeca307c-9ee2-45b9-b465-f7522d30bc8a)

O nome do arquivo salvo é padronizado no formato `historico_JohnDoe_2024-01-23.pdf`, este padrão é importante para a identificação da data de atualização no front-end, que utiliza a informação do nome do arquivo para mostrar esta informação na página. A escolha deste formato foi feita para não adicionar um novo campo na tabela do estudante, nem ter que criar uma tabela nova que armazenasse a URL do histórico e a data de atualização.

Nesta PR também está incluída a correção do sistema que inicia invitations no banco automaticamente para o domínio @edge.ufal.br, a fim de compatibilizar com o front-end, que somente aceita emails com esse domínio. Assim como uma correção nos parâmetros de tamanho máximo de upload de arquivos multipart.






