### PR TITLE
#57 - Adicionar front-end ao docker-compose

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,4 @@
+/client/node_modules
+/client/src
+/client/public
+/client/.next

--- a/.env.dev
+++ b/.env.dev
@@ -1,4 +1,7 @@
-# client
+# Client
+backendRoute=http://server:8080
+
+# Auth
 NEXTAUTH_SECRET=my_ultra_secure_nextauth_secret
 NEXTAUTH_URL=http://localhost:3000
-backendRoute=http:/172.19.70.148:8080
+NEXTAUTH_URL_INTERNAL=http://client:3000

--- a/.env.dev
+++ b/.env.dev
@@ -1,5 +1,5 @@
 # Client
-backendRoute=http://server:8080
+SERVER_URL=http://server:8080
 
 # Auth
 NEXTAUTH_SECRET=my_ultra_secure_nextauth_secret

--- a/.env.dev
+++ b/.env.dev
@@ -1,0 +1,4 @@
+# client
+NEXTAUTH_SECRET=my_ultra_secure_nextauth_secret
+NEXTAUTH_URL=http://localhost:3000
+backendRoute=http:/172.19.70.148:8080

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 data/
 build/
+.env

--- a/client/.env.example
+++ b/client/.env.example
@@ -1,5 +1,0 @@
-NEXTAUTH_SECRET=my_ultra_secure_nextauth_secret
-NEXTAUTH_URL=http://localhost:3000
-backendRoute=http://172.19.70.148:8080
-awsUrl=http://localhost:4566
-awsBucket=student-manager-files

--- a/client/Dockerfile
+++ b/client/Dockerfile
@@ -1,0 +1,18 @@
+FROM node:22
+
+RUN groupadd -g 1001 clientgroup && useradd -r -u 1001 -g clientgroup developer
+
+WORKDIR /app
+
+COPY --chown=developer:clientgroup /client/package*.json ./
+
+RUN ["npm", "install"]
+
+COPY --chown=developer:clientgroup /client .
+
+RUN chown developer:clientgroup /app
+USER developer
+
+EXPOSE 3000
+
+CMD ["sh", "./entrypoint.sh"]

--- a/client/entrypoint.sh
+++ b/client/entrypoint.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+cd /app/
+
+# Executa a aplicação
+npm run dev

--- a/client/next.config.ts
+++ b/client/next.config.ts
@@ -1,4 +1,7 @@
 import type { NextConfig } from 'next';
+import { loadEnvConfig } from '@next/env'
+
+loadEnvConfig('..')
 
 /** @type {import('next').NextConfig} */
 const nextConfig: NextConfig = {

--- a/client/next.config.ts
+++ b/client/next.config.ts
@@ -14,7 +14,7 @@ const nextConfig: NextConfig = {
     ],
   },
   env: {
-    backendRoute: process.env.backendRoute ?? 'http://127.0.0.1:8080',
+    SERVER_URL: process.env.SERVER_URL ?? 'http://127.0.0.1:8080',
     awsUrl: process.env.awsUrl ?? 'http://172.0.0.1:4566',
     awsBucket: process.env.awsBucket ?? 'student-manager-files',
   },

--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.1.0",
       "dependencies": {
         "@hookform/resolvers": "^5.0.1",
+        "@next/env": "^15.3.3",
         "@radix-ui/react-accordion": "^1.2.11",
         "@radix-ui/react-alert-dialog": "^1.1.14",
         "@radix-ui/react-avatar": "^1.1.10",
@@ -891,9 +892,9 @@
       }
     },
     "node_modules/@next/env": {
-      "version": "15.3.2",
-      "resolved": "https://registry.npmjs.org/@next/env/-/env-15.3.2.tgz",
-      "integrity": "sha512-xURk++7P7qR9JG1jJtLzPzf0qEvqCN0A/T3DXf8IPMKo9/6FfjxtEffRJIIew/bIL4T3C2jLLqBor8B/zVlx6g==",
+      "version": "15.3.3",
+      "resolved": "https://registry.npmjs.org/@next/env/-/env-15.3.3.tgz",
+      "integrity": "sha512-OdiMrzCl2Xi0VTjiQQUK0Xh7bJHnOuET2s+3V+Y40WJBAXrJeGA3f+I8MZJ/YQ3mVGi5XGR1L66oFlgqXhQ4Vw==",
       "license": "MIT"
     },
     "node_modules/@next/eslint-plugin-next": {
@@ -6546,6 +6547,12 @@
         "react": "^16.8 || ^17 || ^18 || ^19 || ^19.0.0-rc",
         "react-dom": "^16.8 || ^17 || ^18 || ^19 || ^19.0.0-rc"
       }
+    },
+    "node_modules/next/node_modules/@next/env": {
+      "version": "15.3.2",
+      "resolved": "https://registry.npmjs.org/@next/env/-/env-15.3.2.tgz",
+      "integrity": "sha512-xURk++7P7qR9JG1jJtLzPzf0qEvqCN0A/T3DXf8IPMKo9/6FfjxtEffRJIIew/bIL4T3C2jLLqBor8B/zVlx6g==",
+      "license": "MIT"
     },
     "node_modules/next/node_modules/postcss": {
       "version": "8.4.31",

--- a/client/package.json
+++ b/client/package.json
@@ -12,6 +12,7 @@
   },
   "dependencies": {
     "@hookform/resolvers": "^5.0.1",
+    "@next/env": "^15.3.3",
     "@radix-ui/react-accordion": "^1.2.11",
     "@radix-ui/react-alert-dialog": "^1.1.14",
     "@radix-ui/react-avatar": "^1.1.10",

--- a/client/src/app/(main)/students/[username]/layout.tsx
+++ b/client/src/app/(main)/students/[username]/layout.tsx
@@ -7,7 +7,7 @@ const getData = async (email: string) => {
 
   try {
     const res = await fetch(
-      `${process.env.backendRoute}/api/v1/students/${email}`,
+      `${process.env.SERVER_URL}/api/v1/students/${email}`,
       {
         method: 'GET',
         headers: {

--- a/client/src/app/(main)/students/[username]/profile/page.tsx
+++ b/client/src/app/(main)/students/[username]/profile/page.tsx
@@ -8,7 +8,7 @@ interface StudentProfilePageProps {
 
 const fetchStudentActivities = async (email: string, token: string) => {
   const response = await fetch(
-    `${process.env.backendRoute}/api/v1/activities/${email}`,
+    `${process.env.SERVER_URL}/api/v1/activities/${email}`,
     {
       method: 'GET',
       headers: {
@@ -29,7 +29,7 @@ const fetchStudentActivities = async (email: string, token: string) => {
 
 const fetchStudentData = async (email: string, token: string) => {
   const response = await fetch(
-    `${process.env.backendRoute}/api/v1/students/${email}`,
+    `${process.env.SERVER_URL}/api/v1/students/${email}`,
     {
       method: 'GET',
       headers: {

--- a/client/src/app/(main)/students/page.tsx
+++ b/client/src/app/(main)/students/page.tsx
@@ -6,7 +6,7 @@ const StudentSearchPage = async () => {
 
   const getData = async () => {
     try {
-      const res = await fetch(`${process.env.backendRoute}/api/v1/students`, {
+      const res = await fetch(`${process.env.SERVER_URL}/api/v1/students`, {
         headers: {
           Authorization: `Bearer ${session?.user.authToken}`,
         },

--- a/client/src/features/student-header/avatar-editable.tsx
+++ b/client/src/features/student-header/avatar-editable.tsx
@@ -53,7 +53,7 @@ const AvatarEditable = ({
     formData.append('file', selectedImage as Blob);
 
     const response = await fetch(
-      `${process.env.backendRoute}/api/v1/students/${data?.user?.email}/photo`,
+      `${process.env.SERVER_URL}/api/v1/students/${data?.user?.email}/photo`,
       {
         method: 'PUT',
         body: formData,
@@ -84,7 +84,7 @@ const AvatarEditable = ({
   return (
     <Avatar className="group relative h-[155px] w-[155px]">
       <AvatarImage
-        src={`${process.env.backendRoute?.slice(0, -5)}:4566/student-manager-files/${photoUrl}`}
+        src={`${process.env.SERVER_URL?.slice(0, -5)}:4566/student-manager-files/${photoUrl}`}
         alt="student-profile-picture"
         className="object-cover"
       />
@@ -113,7 +113,7 @@ const AvatarEditable = ({
                   src={
                     selectedImage
                       ? URL.createObjectURL(selectedImage)
-                      : `${process.env.backendRoute?.slice(0, -5)}:4566/student-manager-files/` +
+                      : `${process.env.SERVER_URL?.slice(0, -5)}:4566/student-manager-files/` +
                         photoUrl
                   }
                   alt="Selected"

--- a/client/src/features/student-profile/api/add-activity-req.ts
+++ b/client/src/features/student-profile/api/add-activity-req.ts
@@ -13,7 +13,7 @@ export const addActivity = async (data: any) => {
   data.studentEmail = session?.user.email;
 
   try {
-    const res = await fetch(`${process.env.backendRoute}/api/v1/activities`, {
+    const res = await fetch(`${process.env.SERVER_URL}/api/v1/activities`, {
       headers: {
         Authorization: `Bearer ${token}`,
         'Content-Type': 'application/json',

--- a/client/src/features/student-profile/api/edit-activity-req.ts
+++ b/client/src/features/student-profile/api/edit-activity-req.ts
@@ -13,7 +13,7 @@ export const editActivity = async (data: any) => {
   data.studentEmail = session?.user.email;
 
   try {
-    const res = await fetch(`${process.env.backendRoute}/api/v1/activities`, {
+    const res = await fetch(`${process.env.SERVER_URL}/api/v1/activities`, {
       headers: {
         Authorization: `Bearer ${token}`,
         'Content-Type': 'application/json',

--- a/client/src/features/student-profile/api/edit-info-req.ts
+++ b/client/src/features/student-profile/api/edit-info-req.ts
@@ -13,7 +13,7 @@ export const editInfo = async (data: any) => {
 
   try {
     const res = await fetch(
-      `${process.env.backendRoute}/api/v1/students/${email}`,
+      `${process.env.SERVER_URL}/api/v1/students/${email}`,
       {
         headers: {
           Authorization: `Bearer ${token}`,

--- a/client/src/features/student-profile/api/remove-activity-req.ts
+++ b/client/src/features/student-profile/api/remove-activity-req.ts
@@ -11,7 +11,7 @@ export const removeActivity = async (data: any) => {
   const token = session?.user.authToken;
 
   try {
-    const res = await fetch(`${process.env.backendRoute}/api/v1/activities`, {
+    const res = await fetch(`${process.env.SERVER_URL}/api/v1/activities`, {
       headers: {
         Authorization: `Bearer ${token}`,
         'Content-Type': 'application/json',

--- a/client/src/features/students/components/delete-student.tsx
+++ b/client/src/features/students/components/delete-student.tsx
@@ -27,7 +27,7 @@ export function DeleteStudent(props: { name: string; email: string }) {
 
   async function handleDelete() {
     const res = await fetch(
-      `${process.env.backendRoute}/api/v1/students/` + props.email,
+      `${process.env.SERVER_URL}/api/v1/students/` + props.email,
       {
         method: 'DELETE',
         headers: {

--- a/client/src/features/students/components/student-registration-dialog.tsx
+++ b/client/src/features/students/components/student-registration-dialog.tsx
@@ -483,7 +483,7 @@ export function StudentRegistrationDialog() {
     // Get logged user credentials
     const token = data?.user.authToken;
 
-    const res = await fetch(`${process.env.backendRoute}/api/v1/register`, {
+    const res = await fetch(`${process.env.SERVER_URL}/api/v1/register`, {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',

--- a/client/src/shared/lib/auth.ts
+++ b/client/src/shared/lib/auth.ts
@@ -27,7 +27,7 @@ export const { auth, handlers, signIn, signOut } = NextAuth({
         }
 
         const res = await fetch(
-          `${process.env.backendRoute}/api/v1/auth/login`,
+          `${process.env.SERVER_URL}/api/v1/auth/login`,
           {
             method: 'POST',
             headers: { 'Content-Type': 'application/json' },
@@ -38,7 +38,7 @@ export const { auth, handlers, signIn, signOut } = NextAuth({
         if (res.status === 200) {
           const data = await res.json();
           const user = await fetch(
-            `${process.env.backendRoute}/api/v1/auth/me`,
+            `${process.env.SERVER_URL}/api/v1/auth/me`,
             {
               headers: {
                 Authorization: `Bearer ${data.token}`,

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -38,12 +38,12 @@ services:
     networks:
       - studentmanager-network
 
-  app:
+  server:
     image: gradle:8.5-jdk17-alpine
-    container_name: studentmanager_app
+    container_name: studentmanager_server
     working_dir: /app
     volumes:
-      - .:/app
+      - ./server:/app
     ports:
       - "8080:8080"
     command: [ "gradle", "bootRun" ]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -63,6 +63,20 @@ services:
       - minio
     networks:
       - studentmanager-network
+  client:
+    container_name: studentmanager_client
+    build:
+      context: .
+      dockerfile: ./client/Dockerfile
+    ports:
+      - "3000:3000"
+    volumes:
+      - ./client/src:/app/src
+      - ./client/public:/app/public
+    env_file:
+      - .env
+    networks:
+      - studentmanager-network
 
 networks:
   studentmanager-network:


### PR DESCRIPTION
## Descrição
Configuração do container do frontend e adição ao `docker-compose.yaml`. 

Além disso, foi feita uma correção provisória para o fazer o container do backend funcionar junto aos demais. Isso foi necessário, pois era consideravelmente mais difícil fazer o frontend (dentro do container) se comunicar com o backend (fora do container). 

>[!WARNING]
> Apesar de o backend estar funcionando no docker-compose, é altamente recomendado que façamos uma issue para criar um Dockerfile dedicado ao backend.

Também configurei o frontend para carregar as variáveis de ambiente do arquivo `.env` na pasta raiz do projeto. Sugiro que usemos apenas um arquivo `.env` com todas as variáveis de ambiente e que todas as variáveis que atualmente constam no `docker-compose` sejam carregadas de lá.

No que diz respeito à variáveis de ambiente, troquei o nome da variável da url do backend de `backendRoute` por `SERVER_URL`, por questões estéticas e de consistência (já que estamos chamando a pasta do backend de `/server` e variáveis de ambiente geralmente tem letra maiúscula).

## Container do frontend
O Dockerfile do frontend foi configurado para não copiar as pastas `src` e `public` (além de `node_modules` e `.next`, obviamente), pois no `docker-compose` são feitas duas bind-mounts, o que permite que o container tenha acesso direto às pastas `/client/src` e `/client/public` do host sem precisar ficar reconstruíndo o container. Isso aumenta a velocidade de desenvolvimento, pois as mudanças são propagadas mais rapidamente para a aplicação.

## Capturas de tela
![image](https://github.com/user-attachments/assets/190ad114-afea-4569-a273-069a30265c41)

## Issue relacionada
- [x] #57 